### PR TITLE
Add comparison notes for ontological fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,10 @@ A tutorial example with merge, data-integrity constraints, generating SQL with P
 
 You can read the associated paper which discusses the *science example* in more depth and application of this technology to addressing data-sharing challenges in computational science [here](https://doi.org/10.1016/j.commatsci.2019.04.002) or on [arXiv](https://arxiv.org/abs/1903.10579).
 
+## Ontological fragments prototype
+
+A preliminary `ontological_fragments` module provides Pydantic models for representing partial ontologies and tagging pandas DataFrames with this metadata.
+
 ## Footnotes
 
 <a name="myfootnote1">1</a>: This ID is only for internal bookkeeping and should not be part of the model (all IDs should be interchangeable with any other unique identifier).

--- a/ontological_fragments/COMPARISON.md
+++ b/ontological_fragments/COMPARISON.md
@@ -1,0 +1,64 @@
+# Comparing Ontological Fragments with Existing CQL Models
+
+The `ontological_fragments` module introduces small Pydantic models for describing
+partial ontologies. Each `AttributeFragment`, `EntityFragment`, and
+`OntologicalFragment` simply stores names and optional type information that can
+later be attached to a DataFrame via `OntologicalDataFrame`.
+
+```python
+class AttributeFragment(BaseModel):
+    name: str
+    dtype: Optional[str] = None
+    description: Optional[str] = None
+```
+
+This minimal approach contrasts with the more expressive style used in the rest
+of the repository. For example, `cdi/science_example/inputs/catalysis.py`
+constructs rich CQL models using helper constructors like `Entity`, `Attr`, and
+`FK`:
+
+```python
+job = Entity(
+    name = 'job',
+    desc = 'DFT job',
+    attrs= [Attr('stordir',  Varchar, desc = 'Directory containing log file', id=True),
+            Attr('job_name', Varchar, desc = 'Name of job - arbitrary'),
+            Attr('user',     Varchar, desc = 'Owner of job'),
+            Attr('energy',   Double,  desc = 'Energy result of job')],
+    fks = [FK('struct'), FK('calc')]
+)
+```
+
+These CQL constructs not only define schema elements but also encode
+constraints, path equations, and relationships between entities. The example
+further sets up path equations to express domain knowledge:
+
+```python
+rich_pe = [
+    PathEQ(Path(atom['number']),
+           Path(atom['element'], elem['atomic_number'])),
+    PathEQ(Path(b0['struct'], struct['system_type']),
+           Path(JLit('bulk', String))),
+]
+```
+
+To move `OntologicalFragment` toward this style, we could:
+
+1. **Expand attribute and entity definitions.** Introduce richer field types and
+   support for foreign keys similar to `FK` relationships. This would allow the
+   fragment models to describe connections between fragments instead of just
+   listing attributes.
+2. **Capture constraints.** CQL schemas often specify invariants using
+   `PathEQ` or `EQ`. Extending the fragment models with optional constraint
+   objects would let us represent partial business logic along with schema
+   descriptions.
+3. **Provide builder utilities.** Functions that convert fragment definitions
+   into CQL `Entity` and `Schema` objects would bridge the gap between the
+   lightweight gradual typing approach and the full expressiveness of CQL.
+4. **Annotate DataFrames with provenance.** Much like the CQL examples connect
+   different entities through paths, fragments could track how DataFrame columns
+   correspond to ontology attributes and how they were derived.
+
+By following these directions, the fragment system can remain flexible while
+getting closer to the powerful modeling capabilities showcased in the CQL
+`catalysis` example.

--- a/ontological_fragments/__init__.py
+++ b/ontological_fragments/__init__.py
@@ -1,0 +1,32 @@
+from typing import Optional, List, Any
+from pydantic import BaseModel, Field
+
+class AttributeFragment(BaseModel):
+    """Partial description of an attribute in an ontology."""
+    name: str
+    dtype: Optional[str] = None
+    description: Optional[str] = None
+
+class EntityFragment(BaseModel):
+    """Partial description of an entity consisting of attributes."""
+    name: str
+    attributes: List[AttributeFragment] = Field(default_factory=list)
+    description: Optional[str] = None
+
+class OntologicalFragment(BaseModel):
+    """Collection of entity fragments capturing a portion of an ontology."""
+    name: str
+    entities: List[EntityFragment] = Field(default_factory=list)
+    description: Optional[str] = None
+
+class OntologicalDataFrame(BaseModel):
+    """Associates a pandas DataFrame with an ontological fragment."""
+    data: Any  # Expected to be a pandas.DataFrame
+    fragment: OntologicalFragment
+
+    class Config:
+        arbitrary_types_allowed = True
+
+def tag_dataframe(df: Any, fragment: OntologicalFragment) -> OntologicalDataFrame:
+    """Wrap a DataFrame with ontological metadata."""
+    return OntologicalDataFrame(data=df, fragment=fragment)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 infix
+pydantic
+


### PR DESCRIPTION
## Summary
- outline how ontological fragments compare to the CQL models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_682fc3e627b483279d0c6fc915886464